### PR TITLE
Use multi-source news service and robust Census fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,15 +365,11 @@
 				const historicalResponse = await fetch('data/processed/historical_gva_data.json');
 				const historicalData = await historicalResponse.json();
 
-				// Load current data
-				const currentResponse = await fetch('/api/data');
-				const currentData = await currentResponse.json();
+                                // Load current processed data written by the collector
+                                const currentResponse = await fetch('data/processed/latest.json', { cache: 'no-store' });
+                                const currentData = await currentResponse.json();
 
-				// Combine historical and current data
-				const combinedData = {
-					...currentData,
-					historical: historicalData
-				};
+                                const combinedData = { ...currentData, historical: historicalData };
 
 				updateDashboard(combinedData);
 				showLoadingState(false);

--- a/js/multi-news-service.js
+++ b/js/multi-news-service.js
@@ -11,28 +11,33 @@ class MultiNewsService {
         };
     }
 
-    async getArticles(searchQuery) {
-        // Try each API in order until we get results
+    async search({ q, language = 'en', limitPerSource = 5 } = {}) {
+        const searchQuery = q || '';
         const apis = [
             this.tryMediastack.bind(this),
             this.tryGNews.bind(this),
             this.tryNewsdata.bind(this),
             this.tryNYT.bind(this)
         ];
+        const results = [];
 
         for (const api of apis) {
             try {
                 const articles = await api(searchQuery);
                 if (articles && articles.length > 0) {
-                    return articles;
+                    results.push(...articles.slice(0, limitPerSource));
                 }
             } catch (error) {
                 console.warn(`API attempt failed: ${error.message}`);
-                continue; // Try next API
             }
         }
 
-        return []; // Return empty array if all APIs fail
+        return results;
+    }
+
+    // Backwards compatibility
+    async getArticles(searchQuery) {
+        return this.search({ q: searchQuery });
     }
 
     async tryMediastack(searchQuery) {


### PR DESCRIPTION
## Summary
- replace fragile https-based JSON fetching with axios and content-type validation
- wire MultiNewsService for article retrieval and aggregate search across providers
- point dashboard at generated data/processed/latest.json instead of nonexistent API route

